### PR TITLE
Automatic tag support & more

### DIFF
--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -282,10 +282,14 @@ parseTags = function(tags) {
   var names = [];
   for (var i = 0; i < tags.length; i++) {
     tag = tags[i];
+    animal = tag.animal
+    if (animal == null) {
+      animal = '<i>false-positive</i>'
+    }
     if (tag.automatic) {
-      names.push('<span class="text-danger">' + tag.animal + '</span>');
+      names.push('<span class="text-danger">' + animal + '</span>');
     } else {
-      names.push(tag.animal);
+      names.push(animal);
     }
   }
   td.innerHTML = names.join(' ');

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -249,7 +249,7 @@ parseLocation = function(location) {
     td.innerHTML = latitude + ', ' + longitude;
     return td;
   }
-  td.innerHTML = 'No location.';
+  td.innerHTML = '<span class="text-muted">(unknown)</span>';
   return td;
 };
 
@@ -276,6 +276,29 @@ parseDate = function(dateTime) {
   td.innerHTML = d.toLocaleDateString('en-NZ');
   return td;
 };
+
+parseTags = function(tags) {
+  var td = document.createElement("td");
+  var names = [];
+  for (var i = 0; i < tags.length; i++) {
+    tag = tags[i];
+    if (tag.automatic) {
+      names.push('<span class="text-danger">' + tag.animal + '</span>');
+    } else {
+      names.push(tag.animal);
+    }
+  }
+  td.innerHTML = names.join(' ');
+  return td;
+};
+
+parseOther = function(datapoint) {
+  // Airplane and battery status can go here.
+  var td = document.createElement("td");
+  td.innerHTML = '<span class="text-muted">-</span>';
+  return td;
+};
+
 
 // Generates a Download button to download the recording
 parseDownload = function(id, type) {
@@ -376,19 +399,14 @@ function getTableData() {
       parseFunction: parseDuration
     },
     {
-      tableName: "BatteryLevel",
-      datapointField: "batteryLevel",
-      parseFunction: parseNumber
+      tableName: "Tags",
+      datapointField: "Tags",
+      parseFunction: parseTags,
     },
     {
-      tableName: "BatteryCharging",
-      datapointField: "batteryCharging",
-      parseFunction: parseString,
-    },
-    {
-      tableName: "AirplaneMode",
-      datapointField: "airplaneModeOn",
-      parseFunction: parseBoolean,
+      tableName: "Other",
+      datapointField: "datapoint",
+      parseFunction: parseOther,
     },
     {
       tableName: "File",

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -154,10 +154,6 @@ getAll = function() {
   var deviceId = document.getElementById("deviceSelect").selectedOptions[0].id;
   if (deviceId != "") query.DeviceId = deviceId;
 
-  var tagVal = $('input[name="tagged-or-not"]:checked').val();
-  if (tagVal == 'tagged') query._tagged = true;
-  else if (tagVal == 'not-tagged') query._tagged = false;
-
   document.getElementById('active-query').value = JSON.stringify(query);
   sendQuery();
 };
@@ -171,6 +167,7 @@ sendQuery = function() {
   var query = document.getElementById('active-query').value;
   var limit = Number(document.getElementById('limit').value);
   var offset = Number(document.getElementById('offset').value);
+  var tagMode = $('select#tagMode').val();
 
   var url = recordingsApiUrl
   $.ajax({
@@ -180,6 +177,7 @@ sendQuery = function() {
       where: query,
       limit: limit,
       offset: offset,
+      tagMode: tagMode,
     },
     headers: { Authorization: user.getJWT() },
     success: function(res) {

--- a/public/javascripts/includes/tags.js
+++ b/public/javascripts/includes/tags.js
@@ -9,7 +9,6 @@ tags = {};
  */
 tags.delete = function(event) {
   var id = event.target.tagId;
-  console.log("Deleting tag:", id);
   $.ajax({
     url: api+'/api/v1/tags',
     type: 'DELETE',
@@ -18,7 +17,6 @@ tags.delete = function(event) {
     success: function() {
       var row = event.target.parentNode.parentNode;
       row.parentNode.removeChild(row);
-      console.log("Deleted tag.")
     },
     error: function(err) {
       console.log("Error with deleting tag:", err);
@@ -31,46 +29,51 @@ tags.delete = function(event) {
  */
 tags.addTagToTable = function(tag) {
   var tagsTable = document.getElementById('tags-table');
-  // Make new row.
   var row = tagsTable.insertRow(tagsTable.rows.length);
-  // Add each element to row.
 
-  var elements = [
+  var typeElem = document.createElement('td');
+  if (tag.automatic) {
+    row.className = "bg-danger";
+    typeElem.innerHTML = "Automatic"
+  } else {
+    typeElem.innerHTML = "Human";
+  }
+  row.appendChild(typeElem);
 
-  ];
-
-
-
-  var id = document.createElement('th');
-  id.innerHTML = tag.id;
-  row.appendChild(id);
-  var animal = document.createElement('th');
+  var animal = document.createElement('td');
   animal.innerHTML = tag.animal;
   row.appendChild(animal);
-  var number = document.createElement('th');
+
+  var number = document.createElement('td');
   number.innerHTML = tag.number;
   row.appendChild(number);
-  var event = document.createElement('th');
+
+  var event = document.createElement('td');
   event.innerHTML = tag.event;
   row.appendChild(event);
-  var confidence = document.createElement('th');
+
+  var confidence = document.createElement('td');
   confidence.innerHTML = tag.confidence;
   row.appendChild(confidence);
-  var age = document.createElement('th');
+
+  var age = document.createElement('td');
   age.innerHTML = tag.age;
   row.appendChild(age);
-  var startTime = document.createElement('th');
+
+  var startTime = document.createElement('td');
   startTime.innerHTML = tag.startTime;
   row.appendChild(startTime);
-  var duration = document.createElement('th');
+
+  var duration = document.createElement('td');
   duration.innerHTML = tag.duration;
   row.appendChild(duration);
-  var trapType = document.createElement('th');
+
+  var trapType = document.createElement('td');
   trapType.innerHTML = tag.trapType;
   row.appendChild(trapType);
 
   // Add delete button
-  var del = document.createElement('th');
+  var del = document.createElement('td');
   var deleteButton = document.createElement('button');
   deleteButton.innerHTML = "Delete"
   deleteButton.onclick = tags.delete;
@@ -83,7 +86,6 @@ tags.addTagToTable = function(tag) {
  * Loads all the tags in the list given to the table.
  */
 tags.load = function(loadingTags) {
-  console.log("Loading tags into table.");
   for (var i in loadingTags) {
     tags.addTagToTable(loadingTags[i]);
   }
@@ -121,10 +123,8 @@ tags.new = function() {
 };
 
 tags.send = function(tag) {
-  console.log("New tag:", tag);
   var data = {recordingId: id};
   data.tag = JSON.stringify(tag);
-  console.log(data);
   // Upload new tag
   $.ajax({
     url: api + '/api/v1/tags',
@@ -132,7 +132,6 @@ tags.send = function(tag) {
     headers: { 'Authorization': user.getJWT() },
     data: data,
     success: function(res) {
-      console.log("Success");
       tag.id = res.tagId;
       tags.addTagToTable(tag);
     },

--- a/public/stylesheets/getRecordings.css
+++ b/public/stylesheets/getRecordings.css
@@ -1,0 +1,3 @@
+.form-group {
+  margin-bottom: 5px;
+}

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -3,6 +3,7 @@ html
   head
     title Get Recordings
     include includes/base.pug
+    link(href='/stylesheets/getRecordings.css', rel='stylesheet', media='screen')
     script(type='text/javascript', src='javascripts/getRecordings.js')
 
   body
@@ -12,22 +13,22 @@ html
     .col-md-3
       h4.
         Make new condition
-      .input-group
-        label Before date
-        input#before-date(type='date')
-        input(type='button', value='Add', onclick="addBeforeDate()")
-      .input-group
-        label After date
-        input#after-date(type='date')
-        input(type='button', value='Add', onclick="addAfterDate()")
-      .input-group
-        label Longer than (seconds):
-        input#longer-than(type='number')
-        input(type='button', value='Add', onclick="addLongerThan()")
-      .input-group
-        label Shorter than (seconds):
-        input#shorter-than(type='number')
-        input(type='button', value='Add', onclick="addShorterThan()")
+      .form-group.row
+        label.col-md-4 Before date
+        input#before-date(type='date').col-md-4
+        input(type='button', value='Add', onclick="addBeforeDate()").col-md-2
+      .form-group.row
+        label.col-md-4 After date
+        input#after-date(type='date').col-md-4
+        input(type='button', value='Add', onclick="addAfterDate()").col-md-2
+      .form-group.row
+        label.col-md-4 Longer than(s)
+        input#longer-than(type='number').col-md-4
+        input(type='button', value='Add', onclick="addLongerThan()").col-md-2
+      .form-group.row
+        label.col-md-4 Shorter than(s)
+        input#shorter-than(type='number').col-md-4
+        input(type='button', value='Add', onclick="addShorterThan()").col-md-2
 
     .col-md-3
       h4.
@@ -36,30 +37,35 @@ html
     .col-md-4
       h4.
         Query
-      input(type='button', value='Get all.', onclick='getAll()')
-      label Devices:
-      select#deviceSelect
-        option all
-      br
-      label Tagged
-      input(name="tagged-or-not", type="radio", value='tagged')
-      label Not tagged
-      input(name="tagged-or-not", type="radio", value='not-tagged')
-      label Both
-      input(name="tagged-or-not", type="radio", value='both', checked)
-      br
-      input(type='button', value='Get all from conditions.', onclick='fromConditions()')
+      .form-group.row
+        label.col-sm-2 Device
+        select#deviceSelect.col-sm-6
+          option all
+      .form-group.row
+        label.col-sm-2 Tags
+        select#tagMode.col-sm-6
+            option(value="any" selected) any
+            option(value="untagged") untagged only
+            option(value="tagged") tagged only
+            option(value="automatic-only") automatic only
+            option(value="human-only") human only
+            option(value="automatic+human") both automatic & human
+      .form-group.row
+        label.col-md-2 Limit
+        input#limit.col-md-2(type='number', value=100)
+      .form-group.row
+        label.col-md-2 Offset
+        input#offset.col-md-2(type='number', value=0)
+        input.col-md-1(type='button', value='<', onclick="dec()")
+        input.col-md-1(type='button', value='>', onclick="inc()")
+      .form-group.row
+        input(type='button', value='Get all', onclick='getAll()').col-md-2
+        input(type='button', value='Get all from conditions', onclick='fromConditions()').col-md-3
       br
       label Active query
       input#active-query(type='text', value='{}')
       input(type='button', value='Send', onclick="sendQuery()")
       br
-      label.col-md-2 Limit
-      input#limit.col-md-3(type='number', value=100)
-      label.col-md-2 Offset
-      input#offset.col-md-3(type='number', value=0)
-      input.col-md-1(type='button', value='<', onclick="dec()")
-      input.col-md-1(type='button', value='>', onclick="inc()")
       label#count 0 results
 
     .col-md-1

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -70,7 +70,7 @@ html
 
     .col-md-1
 
-  table#results-table(class="table table-striped")
+  table#results-table(class="table table-striped table-hover")
     tr
       th View
       th ID
@@ -80,8 +80,7 @@ html
       th Time
       th Date
       th Duration
-      th BatteryLevel
-      th BatteryCharging
-      th AirplaneMode
+      th Tags
+      th Other
       th File
       th Raw data

--- a/views/includes/tags.pug
+++ b/views/includes/tags.pug
@@ -68,15 +68,17 @@ form.form-horizontal#tagForm(onsubmit="return false")
     input#tagStopTimeInput(type="text", placeholder="min:sec", value="", pattern="(\\d)?(\\d):[0-5][0-9]", title="Minutes:Seconds (2:31)")
     button(onclick="goToEndTime()") go to end time
     button(onclick="setEndTimeAsCurrentTime()") set to current time
-table#tags-table(class="table table-striped")
-  tr
-    th(type='id') ID
-    th(type='animal') Animal
-    th(type='number') Number
-    th Event
-    th Confidence
-    th Age
-    th Start Time
-    th Duration
-    th Trap Type
-    th
+table(class="table table-hover")
+  thead
+    tr
+      th(type='type') Type
+      th(type='animal') Animal
+      th(type='number') Number
+      th Event
+      th Confidence
+      th Age
+      th Start Time
+      th Duration
+      th Trap Type
+      th
+  tbody#tags-table

--- a/views/viewRecording.pug
+++ b/views/viewRecording.pug
@@ -14,7 +14,7 @@ html
       h3.center-block Video Player
       .container.col-md-6
         video#player.center-block(width=100, controls)
-          Brouser not supported for playing video.
+          Browser not supported for playing video.
       .container.col-md-6
         .form-horizontal
           .form-group


### PR DESCRIPTION
* Added support for new "tagMode" query field. Instead of the tagged/not-tagged radio buttons there's now a drop down for selecting the various tag modes.
* The layout of the query UI has been tidied up a bit for clarity.
* Indicate automatic/human tags when viewing a recording
* Show tags for query results. A new Tags column has been added which shows the tags for each
recording. Automatic tags are highlighted in a different colour. In order to make room for tags, the currently unused BatteryCharging, BatteryLevel & AirplaneMode columns have been merged into a new Other column.