### PR TITLE
Allow navigation by "interesting" tags

### DIFF
--- a/public/javascripts/viewRecording.js
+++ b/public/javascripts/viewRecording.js
@@ -38,7 +38,7 @@ function getRecordingError(result) {
   console.log("ERROR");
 }
 
-function previousRecording(tagged) {
+function previousRecording(tagMode) {
   console.log('Go to previous recording.');
   // Goes to the previous recording from that device.
   if (recording == null) return;
@@ -46,9 +46,6 @@ function previousRecording(tagged) {
     DeviceId: recording.Device.id,
     recordingDateTime: {lt: recording.recordingDateTime},
   };
-  if (tagged == false) {
-    query._tagged = false;
-  }
   headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   $.ajax({
@@ -56,6 +53,7 @@ function previousRecording(tagged) {
     type: 'GET',
     data: {
       where: JSON.stringify(query),
+      tagMode: tagMode,
       limit: 1,
       offset: 0,
     },
@@ -74,7 +72,7 @@ function previousRecording(tagged) {
   });
 }
 
-function nextRecording(tagged) {
+function nextRecording(tagMode) {
   console.log('Go to next recording.')
   // Goes to the next recording from that device
   if (recording == null) return;
@@ -82,9 +80,6 @@ function nextRecording(tagged) {
     DeviceId: recording.Device.id,
     recordingDateTime: {gt: recording.recordingDateTime},
   };
-  if (tagged == false) {
-    query._tagged = false;
-  }
   headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   $.ajax({
@@ -92,6 +87,7 @@ function nextRecording(tagged) {
     type: 'GET',
     data: {
       where: JSON.stringify(query),
+      tagMode: tagMode,
       limit: 1,
       offset: 0,
       order: '[["recordingDateTime", "ASC"]]',
@@ -200,7 +196,7 @@ function deleteRecording() {
     headers: headers,
     success: function(res) {
       console.log(res);
-      nextRecording(false);
+      nextRecording('any');
     },
     error: function(err) {
       console.log(err);

--- a/public/javascripts/viewRecording.js
+++ b/public/javascripts/viewRecording.js
@@ -5,7 +5,7 @@ document.onkeypress = function (e) {
   if (document.activeElement.tagName.toUpperCase() != 'BODY') { return; }
   var key = e.key;
   if (key == 'n') {
-    nextRecording(false);
+    nextRecording("next", "no-human");
   } else if (key == 'f') {
     falsePositive();
   } else if (key == 'a') {
@@ -38,14 +38,30 @@ function getRecordingError(result) {
   console.log("ERROR");
 }
 
-function previousRecording(tagMode) {
-  console.log('Go to previous recording.');
-  // Goes to the previous recording from that device.
+function nextRecording(direction, tagMode, tags) {
   if (recording == null) return;
+
   var query = {
     DeviceId: recording.Device.id,
-    recordingDateTime: {lt: recording.recordingDateTime},
   };
+  var order
+  switch (direction) {
+  case "next":
+    query.recordingDateTime = {gt: recording.recordingDateTime};
+    order = "ASC";
+    break;
+  case "previous":
+    query.recordingDateTime = {lt: recording.recordingDateTime};
+    order = "DESC";
+    break;
+  default:
+    throw `invalid direction: '${direction}'`;
+  }
+
+  if (!tags) {
+    tags = null;
+  }
+
   headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   $.ajax({
@@ -54,13 +70,15 @@ function previousRecording(tagMode) {
     data: {
       where: JSON.stringify(query),
       tagMode: tagMode,
+      tags: JSON.stringify(tags),
       limit: 1,
       offset: 0,
+      order: JSON.stringify([["recordingDateTime", order]]),
     },
     headers: headers,
     success: function(res) {
       if (res.rows.length == 0) {
-        window.alert("No previous recording from this device.");
+        window.alert(`No ${direction} recording from this device.`);
         return;
       }
       window.location.href = "/view_recording/"+res.rows[0].id;
@@ -72,40 +90,7 @@ function previousRecording(tagMode) {
   });
 }
 
-function nextRecording(tagMode) {
-  console.log('Go to next recording.')
-  // Goes to the next recording from that device
-  if (recording == null) return;
-  var query = {
-    DeviceId: recording.Device.id,
-    recordingDateTime: {gt: recording.recordingDateTime},
-  };
-  headers = {};
-  if (user.isLoggedIn()) headers.Authorization = user.getJWT();
-  $.ajax({
-    url: recordingsApiUrl,
-    type: 'GET',
-    data: {
-      where: JSON.stringify(query),
-      tagMode: tagMode,
-      limit: 1,
-      offset: 0,
-      order: '[["recordingDateTime", "ASC"]]',
-    },
-    headers: headers,
-    success: function(res) {
-      if (res.rows.length == 0) {
-        window.alert("No next recording from this device.");
-        return;
-      }
-      window.location.href = "/view_recording/"+res.rows[0].id;
-    },
-    error: function(err) {
-      console.log('Error');
-      console.log(err);
-    },
-  });
-}
+
 
 function getRecordingSuccess(result, status) {
   if (!result.success)
@@ -196,7 +181,7 @@ function deleteRecording() {
     headers: headers,
     success: function(res) {
       console.log(res);
-      nextRecording('any');
+      nextRecording('next', 'any');
     },
     error: function(err) {
       console.log(err);

--- a/public/stylesheets/videoRecording.css
+++ b/public/stylesheets/videoRecording.css
@@ -1,4 +1,8 @@
 #player {
-	height: 100%;
-	width: 100%;
+    height: 100%;
+    width: 100%;
+}
+
+.button-row {
+    padding-bottom: 20px;
 }

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -39,7 +39,7 @@ html
         Query
       .form-group.row
         label.col-sm-2 Device
-        select#deviceSelect.col-sm-6
+        select#deviceSelect.cml-sm-6
           option all
       .form-group.row
         label.col-sm-2 Tags

--- a/views/viewRecording.pug
+++ b/views/viewRecording.pug
@@ -11,36 +11,41 @@ html
   body
     include includes/navbar.pug
     .container
-      h3.center-block Video Player
       .container.col-md-6
         video#player.center-block(width=100, controls)
           Browser not supported for playing video.
-      .container.col-md-6
-        .form-horizontal
+      .col-md-6
+        .form-horizonal
           .form-group
-            label.col-xs-3.text-right Date:
-            div.col-xs-2#date-text
-            button.col-xs-5(onclick="deleteRecording()") Delete
+            label.col-xs-3 Device
+            .col#device-text
           .form-group
-            label.col-xs-3.text-right Time:
-            div#time-text
+            label.col-xs-3 Time
+            .col
+              span#date-text
+              | &nbsp;
+              span#time-text
           .form-group
-            label.col-xs-3.text-right Device:
-            div#device-text
+            label.col-xs-3 Processing
+            .col#processing-state-text
           .form-group
-            label.col-xs-3.text-right Processing state:
-            div#processing-state-text
-          .form-group
-            label.col-xs-3.text-right Comment:
+            label.col-xs-3 Comment
             input.col-xs-7#comment-text
-            button.col-xs-2(onclick="updateComment()") Save
+            | &nbsp;
+            button.col(onclick="updateComment()") Save
           .form-group
-            button.col-xs-5(onclick="previousRecording('any')") Previous from device
-            button.col-xs-5(onclick="nextRecording('any')") Next from device
-          .form-group
-            button.col-xs-5(onclick="previousRecording('no-human')") Previous not tagged
-            button.col-xs-5(onclick="nextRecording('no-human')") Next not tagged
-          .form-group
-            input.col-xs-5(type="submit", value="Add new tag", onclick="tags.new()" )
-            button.col-xs-5(onclick="falsePositive()") False positive
+            button.col(onclick="deleteRecording()") Delete
+          .form-group.button-row
+            button.col-xs-4(onclick="nextRecording('next', 'any')" title="Next for device") < Device
+            button.col-xs-4(onclick="nextRecording('previous', 'any')" title="Previous for device") Device >
+          .form-group.button-row
+            button.col-xs-4(onclick="nextRecording('next', 'no-human')" title="Next for device, not manually tagged") < Untagged
+            button.col-xs-4(onclick="nextRecording('previous', 'no-human')" title="Previous for device, not manually tagged") Untagged >
+          .form-group.button-row
+            button.col-xs-4(onclick="nextRecording('next', 'any', ['interesting'])" title="Next for device, skipping birds & F/P") < Interesting
+            button.col-xs-4(onclick="nextRecording('previous', 'any', ['interesting'])" title="Previous for device, skipping bird & F/P") Interesting >
+          .form-group.button-row
+            input.col-xs-4(type="submit", value="Add new tag", onclick="tags.new()" )
+            button.col-xs-4(onclick="falsePositive()") False positive
+
     include includes/tags.pug

--- a/views/viewRecording.pug
+++ b/views/viewRecording.pug
@@ -35,11 +35,11 @@ html
             input.col-xs-7#comment-text
             button.col-xs-2(onclick="updateComment()") Save
           .form-group
-            button.col-xs-5(onclick="previousRecording()") Previous from device
-            button.col-xs-5(onclick="previousRecording(false)") Previous not tagged
+            button.col-xs-5(onclick="previousRecording('any')") Previous from device
+            button.col-xs-5(onclick="nextRecording('any')") Next from device
           .form-group
-            button.col-xs-5(onclick="nextRecording()") Next from device
-            button.col-xs-5(onclick="nextRecording(false)") Next not tagged
+            button.col-xs-5(onclick="previousRecording('no-human')") Previous not tagged
+            button.col-xs-5(onclick="nextRecording('no-human')") Next not tagged
           .form-group
             input.col-xs-5(type="submit", value="Add new tag", onclick="tags.new()" )
             button.col-xs-5(onclick="falsePositive()") False positive


### PR DESCRIPTION
- Fixed the next/prev untagged buttons. These had been broken since the "tagMode" query field was
introduced. The next/prev untagged buttons now work through the videos which haven't been tagged or only have an automatic tag.
- Allow query by next/prev "interesting" where "interesting" is defined as "not bird or false positive".
- Also:
  * improved layout of the view recording UI
  * added hover text for next/prev buttons
  * merged previousRecording() & nextRecording() into one to avoid code duplication