### PR TITLE
Various small tweaks

### DIFF
--- a/public/javascripts/includes/tags.js
+++ b/public/javascripts/includes/tags.js
@@ -53,7 +53,7 @@ tags.addTagToTable = function(tag) {
   row.appendChild(event);
 
   var confidence = document.createElement('td');
-  confidence.innerHTML = tag.confidence;
+  confidence.innerHTML = precisionRound(tag.confidence, 2);
   row.appendChild(confidence);
 
   var age = document.createElement('td');
@@ -216,4 +216,9 @@ tags.parseString = function(id) {
 tags.parseConfidence = function(id) {
   var val = $('input[name="' + id + '"]:checked').val();
   return val;
+}
+
+function precisionRound(number, precision) {
+  var factor = Math.pow(10, precision);
+  return Math.round(number * factor) / factor;
 }

--- a/public/javascripts/includes/tags.js
+++ b/public/javascripts/includes/tags.js
@@ -36,7 +36,7 @@ tags.addTagToTable = function(tag) {
     row.className = "bg-danger";
     typeElem.innerHTML = "Automatic"
   } else {
-    typeElem.innerHTML = "Human";
+    typeElem.innerHTML = "Manual";
   }
   row.appendChild(typeElem);
 

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -48,8 +48,8 @@ html
             option(value="untagged") untagged only
             option(value="tagged") tagged only
             option(value="automatic-only") automatic only
-            option(value="human-only") human only
-            option(value="automatic+human") both automatic & human
+            option(value="human-only") manual only
+            option(value="automatic+human") both automatic & manual
       .form-group.row
         label.col-md-2 Limit
         input#limit.col-md-2(type='number', value=100)

--- a/views/includes/tags.pug
+++ b/views/includes/tags.pug
@@ -5,6 +5,7 @@ form.form-horizontal#tagForm(onsubmit="return false")
     label.col-xs-2.text-right Animal:
     select#tagAnimalInput
       option bird
+      option bird/kiwi
       option rat
       option possum
       option hedgehog

--- a/views/includes/tags.pug
+++ b/views/includes/tags.pug
@@ -72,7 +72,7 @@ form.form-horizontal#tagForm(onsubmit="return false")
 table(class="table table-hover")
   thead
     tr
-      th(type='type') Type
+      th(type='type') Tag Type
       th(type='animal') Animal
       th(type='number') Number
       th Event

--- a/views/viewRecording.pug
+++ b/views/viewRecording.pug
@@ -36,14 +36,14 @@ html
           .form-group
             button.col(onclick="deleteRecording()") Delete
           .form-group.button-row
-            button.col-xs-4(onclick="nextRecording('next', 'any')" title="Next for device") < Device
-            button.col-xs-4(onclick="nextRecording('previous', 'any')" title="Previous for device") Device >
+            button.col-xs-4(onclick="nextRecording('previous', 'any')" title="Previous for device") < Device
+            button.col-xs-4(onclick="nextRecording('next', 'any')" title="Next for device") Device >
           .form-group.button-row
-            button.col-xs-4(onclick="nextRecording('next', 'no-human')" title="Next for device, not manually tagged") < Untagged
-            button.col-xs-4(onclick="nextRecording('previous', 'no-human')" title="Previous for device, not manually tagged") Untagged >
+            button.col-xs-4(onclick="nextRecording('previous', 'no-human')" title="Previous for device, not manually tagged") < Untagged
+            button.col-xs-4(onclick="nextRecording('next', 'no-human')" title="Next for device, not manually tagged") Untagged >
           .form-group.button-row
-            button.col-xs-4(onclick="nextRecording('next', 'any', ['interesting'])" title="Next for device, skipping birds & F/P") < Interesting
-            button.col-xs-4(onclick="nextRecording('previous', 'any', ['interesting'])" title="Previous for device, skipping bird & F/P") Interesting >
+            button.col-xs-4(onclick="nextRecording('previous', 'any', ['interesting'])" title="Previous for device, skipping bird & F/P") < Interesting
+            button.col-xs-4(onclick="nextRecording('next', 'any', ['interesting'])" title="Next for device, skipping birds & F/P") Interesting >
           .form-group.button-row
             input.col-xs-4(type="submit", value="Add new tag", onclick="tags.new()" )
             button.col-xs-4(onclick="falsePositive()") False positive


### PR DESCRIPTION
Add new "bird/kiwi" animal type

---

Swap prev/next button ordering to make them more intuitive

---

Refer to non-automatic tags as "manual" instead of "human"

"human" was confusing as we also have a animal type with that name.

---

Round confidence numbers to 2 decimal places

Automatic tags tend to condfidence numbers with many digits after the decimal place. Rounding to 2 decimal places makes these somewhat easier to look at.
