### PR TITLE
Group and user api fixes

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,23 @@
+env:
+  browser: true
+parserOptions:
+  ecmaVersion: 8
+extends: 'eslint:recommended'
+rules:
+  indent:
+    - error
+    - 2
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - off
+  semi:
+    - error
+    - always
+  no-console:
+    - off
+  no-undef:
+    - warn
+  no-unused-vars:
+    - warn

--- a/public/javascripts/devices.js
+++ b/public/javascripts/devices.js
@@ -67,7 +67,7 @@ function clearTable(tableId) {
 
 function isAdmin(device) {
   for (var i in device.Users) {
-    if (device.Users[i].id == user.getData().id) {
+    if (device.Users[i].id == user.getAttr('id')) {
       return device.Users[i].DeviceUsers.admin;
     }
   }

--- a/public/javascripts/devices.js
+++ b/public/javascripts/devices.js
@@ -1,5 +1,4 @@
 const devicesApiUrl = api + '/api/v1/devices';
-const usersApiUrl = api + '/api/v1/users';
 const deviceUsersApiUrl = api + '/api/v1/devices/users';
 const params = new URLSearchParams(location.search);
 var devices = [];
@@ -10,7 +9,7 @@ window.onload = async function() {
   await loadDevices();
   updateActiveDevice();
   loadDeviceUsers();
-}
+};
 
 function updateActiveDevice() {
   activeDevice = null;
@@ -26,7 +25,7 @@ function updateDeviceTitle() {
   const title = document.getElementById('device-title');
   const devicename = params.get('devicename');
   if (devicename == null) {
-    title.innerHTML = 'Devices'
+    title.innerHTML = 'Devices';
   } else {
     title.innerHTML = 'Device ' + devicename;
   }
@@ -64,7 +63,7 @@ function clearTable(tableId) {
   var table = document.getElementById(tableId);
   var rowCount = table.rows.length;
   while (--rowCount) table.deleteRow(rowCount);
-};
+}
 
 function isAdmin(device) {
   for (var i in device.Users) {
@@ -76,7 +75,7 @@ function isAdmin(device) {
 }
 
 async function loadDeviceUsers() {
-  var devicename = params.get('devicename')
+  var devicename = params.get('devicename');
   if (devicename == null) {
     return;
   }
@@ -109,16 +108,16 @@ function addUserToDeviceButton() {
 }
 
 async function addUserToDevice(username, admin) {
-  const users = await getUsers({username: username});
-  if (users.length != 1) {
+  const targetUser = await user.get(username);
+  if (targetUser === null) {
     return;
   }
 
-  const headers = {}
+  const headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   const data = {
     deviceId: activeDevice.id,
-    userId: users[0].id,
+    userId: targetUser.id,
     admin: admin,
   };
   $.ajax({
@@ -139,15 +138,16 @@ function removeUserFromDeviceButton() {
 }
 
 async function removeUserFromDevice(username) {
-  const users = await getUsers({username: username});
-  if (users.length != 1) {
+  const targetUser = await user.get(username);
+  if (targetUser === null) {
     return;
   }
-  const headers = {}
+
+  const headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   const data = {
     deviceId: activeDevice.id,
-    userId: users[0].id,
+    userId: targetUser.id,
   };
   $.ajax({
     url: deviceUsersApiUrl,
@@ -183,24 +183,6 @@ function getDevices() {
         return resolve();
       },
       error: reject,
-    })
-  });
-}
-
-function getUsers(where) {
-  const data = {where: JSON.stringify(where) };
-  return new Promise(function(resolve, reject) {
-    const headers = {};
-    if (user.isLoggedIn()) headers.Authorization = user.getJWT();
-    $.ajax({
-      url: usersApiUrl,
-      type: 'GET',
-      data: data,
-      headers: headers,
-      success: function (result) {
-        return resolve(result.users);
-      },
-      error: reject,
-    })
+    });
   });
 }

--- a/public/javascripts/groups.js
+++ b/public/javascripts/groups.js
@@ -1,5 +1,4 @@
 const groupsApiUrl = api + '/api/v1/groups';
-const usersApiUrl = api + '/api/v1/users';
 const groupUsersApiUrl = api + '/api/v1/groups/users';
 const params = new URLSearchParams(location.search);
 
@@ -7,13 +6,13 @@ window.onload = function() {
   updateGroupTitle();
   loadGroups();
   loadGroupUsersAndDevices();
-}
+};
 
 function updateGroupTitle() {
   const title = document.getElementById('group-title');
   const groupname = params.get('groupname');
   if (groupname == null) {
-    title.innerHTML = 'Groups'
+    title.innerHTML = 'Groups';
   } else {
     title.innerHTML = 'Group ' + groupname;
   }
@@ -67,22 +66,22 @@ function isAdmin(group) {
 }
 
 async function loadGroupUsersAndDevices() {
-  var groupname = params.get('groupname')
+  var groupname = params.get('groupname');
   console.log('loading group', groupname);
   if (groupname == null) {
     return;
   }
   const groups = await getGroups({ groupname: groupname });
   const users = groups[0].Users;
-  clearTable('users-table')
+  clearTable('users-table');
   console.log(users);
   for (var i in users) {
     adduserToTable(users[i]);
   }
-  clearTable('devices-table')
+  clearTable('devices-table');
   const devices = groups[0].Devices;
   for (var d in devices) {
-    addDeviceToTable(devices[d])
+    addDeviceToTable(devices[d]);
   }
 }
 
@@ -120,8 +119,8 @@ function addUserToGroupButton() {
 }
 
 async function addUserToGroup(username, admin) {
-  const users = await getUsers({username: username});
-  if (users.length != 1) {
+  const targetUser = await user.get(username);
+  if (targetUser === null) {
     console.log('user not found');
     return;
   }
@@ -130,11 +129,11 @@ async function addUserToGroup(username, admin) {
     console.log('group not found');
     return;
   }
-  const headers = {}
+  const headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   const data = {
     groupId: groups[0].id,
-    userId: users[0].id,
+    userId: targetUser.id,
     admin: admin,
   };
   $.ajax({
@@ -158,8 +157,8 @@ function removeUserFromGroupButton() {
 }
 
 async function removeUserFromGroup(username) {
-  const users = await getUsers({username: username});
-  if (users.length != 1) {
+  const targetUserl = await user.get(username);
+  if (targetUser === null) {
     console.log('user not found');
     return;
   }
@@ -168,11 +167,11 @@ async function removeUserFromGroup(username) {
     console.log('group not found');
     return;
   }
-  const headers = {}
+  const headers = {};
   if (user.isLoggedIn()) headers.Authorization = user.getJWT();
   const data = {
     groupId: groups[0].id,
-    userId: users[0].id,
+    userId: targetUser.id,
   };
   $.ajax({
     url: groupUsersApiUrl,
@@ -203,24 +202,6 @@ function getGroups(where) {
         return resolve(result.groups);
       },
       error: reject,
-    })
-  });
-}
-
-function getUsers(where) {
-  const data = {where: JSON.stringify(where) };
-  const headers = {};
-  if (user.isLoggedIn()) headers.Authorization = user.getJWT();
-  return new Promise(function(resolve, reject) {
-    $.ajax({
-      url: usersApiUrl,
-      type: 'GET',
-      data: data,
-      headers: headers,
-      success: function (result) {
-        return resolve(result.users);
-      },
-      error: reject,
-    })
+    });
   });
 }

--- a/public/javascripts/groups.js
+++ b/public/javascripts/groups.js
@@ -58,7 +58,7 @@ clearTable = function(tableId) {
 
 function isAdmin(group) {
   for (var i in group.Users) {
-    if (group.Users[i].id == user.getData().id) {
+    if (group.Users[i].id == user.getAttr('id')) {
       return group.Users[i].GroupUsers.admin;
     }
   }

--- a/public/javascripts/includes/navbar.js
+++ b/public/javascripts/includes/navbar.js
@@ -6,7 +6,7 @@
 if (user.isLoggedIn()) {
   document.getElementById('navbar-logout').onclick = user.logout;
   document.getElementById('navbar-hello-user').innerText =
-    'Hello ' + user.get("username");
+    'Hello ' + user.getAttr("username");
   $("#navbar-user-details").show();
 } else {
   $("#navbar-login").show();

--- a/public/javascripts/includes/user.js
+++ b/public/javascripts/includes/user.js
@@ -126,8 +126,8 @@ user.get = async function(username) {
       headers: { 'Authorization': user.getJWT() },
       success: (result) => resolve(result.userData),
       error: (resp) => {
-        // 400 status means the user doesn't exist.
-        if (resp.status == 400) {
+        // 422 status means the user doesn't exist.
+        if (resp.status == 422) {
           resolve(null);
         }
         return reject(resp.statusText);

--- a/public/javascripts/includes/user.js
+++ b/public/javascripts/includes/user.js
@@ -4,7 +4,7 @@ user.logout = function() {
   localStorage.removeItem('userData');
   localStorage.removeItem('JWT');
   window.location.reload(false);
-}
+};
 
 user.login = function(passwordElement, usernameElement) {
   var password = document.getElementById('inputPassword').value;
@@ -28,7 +28,7 @@ user.login = function(passwordElement, usernameElement) {
       document.getElementById('messages').innerHTML = messages;
     }
   });
-}
+};
 
 user.register = function(passEle1, passEle2, usernameEle) {
 
@@ -67,33 +67,33 @@ user.register = function(passEle1, passEle2, usernameEle) {
       window.alert("Error with registering a new user.");
     }
   });
-}
+};
 
 user.getData = function() {
   if (user.isLoggedIn())
     return JSON.parse(localStorage.getItem('userData'));
   else
     return null;
-}
+};
 
 user.get = function(field) {
   if (user.isLoggedIn() == false)
     return null;
   else
-    return user.getData()[field]
-}
+    return user.getData()[field];
+};
 
 user.isLoggedIn = function() {
   if (JSON.parse(localStorage.getItem('userData')))
     return true;
   else
     return false;
-}
+};
 
 // Returns the JSON Web Token
 user.getJWT = function() {
   return localStorage.getItem('JWT');
-}
+};
 
 user.updateUserData = function() {
   if (!user.isLoggedIn()) {
@@ -112,7 +112,30 @@ user.updateUserData = function() {
       window.alert('Error with loading user data.');
     }
   });
-}
+};
+
+
+user.get = async function(username) {
+  if (!user.isLoggedIn()) {
+    throw "must be logged in";
+  }
+  return new Promise(function(resolve, reject) {
+    $.ajax({
+      url: api + "/api/v1/users/" + username,
+      type: 'GET',
+      headers: { 'Authorization': user.getJWT() },
+      success: (result) => resolve(result.userData),
+      error: (resp) => {
+        // 400 status means the user doesn't exist.
+        if (resp.status == 400) {
+          resolve(null);
+        }
+        return reject(resp.statusText);
+      },
+    });
+  });
+};
+
 
 user.getTagDefaults = function() {
   var defaults = JSON.parse(localStorage.getItem('tagDefaults'));
@@ -120,7 +143,7 @@ user.getTagDefaults = function() {
     return {};
   else
     return defaults;
-}
+};
 
 user.setTagDefault = function(key, val) {
   var defaults = JSON.parse(localStorage.getItem('tagDefaults'));
@@ -128,4 +151,4 @@ user.setTagDefault = function(key, val) {
     defaults = {};
   defaults[key] = val;
   localStorage.setItem('tagDefaults', JSON.stringify(defaults));
-}
+};

--- a/public/javascripts/includes/user.js
+++ b/public/javascripts/includes/user.js
@@ -96,11 +96,11 @@ user.getJWT = function() {
 }
 
 user.updateUserData = function() {
-  if (!user.isLoggedIn)
+  if (!user.isLoggedIn()) {
     return;
-
+  }
   $.ajax({
-    url: api + '/api/v1/users',
+    url: api + '/api/v1/users/' + user.get("username"),
     type: 'get',
     headers: { 'Authorization': user.getJWT() },
     success: function(res) {

--- a/public/javascripts/includes/user.js
+++ b/public/javascripts/includes/user.js
@@ -69,18 +69,18 @@ user.register = function(passEle1, passEle2, usernameEle) {
   });
 };
 
-user.getData = function() {
+user.getAllAttrs = function() {
   if (user.isLoggedIn())
     return JSON.parse(localStorage.getItem('userData'));
   else
     return null;
 };
 
-user.get = function(field) {
+user.getAttr = function(field) {
   if (user.isLoggedIn() == false)
     return null;
   else
-    return user.getData()[field];
+    return user.getAllAttrs()[field];
 };
 
 user.isLoggedIn = function() {
@@ -100,7 +100,7 @@ user.updateUserData = function() {
     return;
   }
   $.ajax({
-    url: api + '/api/v1/users/' + user.get("username"),
+    url: api + '/api/v1/users/' + user.getAttr("username"),
     type: 'get',
     headers: { 'Authorization': user.getJWT() },
     success: function(res) {

--- a/public/javascripts/login.js
+++ b/public/javascripts/login.js
@@ -3,5 +3,5 @@ window.onload = function() {
 };
 
 function login() {
-  user.login(document.getElementById('inputPassword').value, document.getElementById('inputUsername').value)
+  user.login(document.getElementById('inputPassword').value, document.getElementById('inputUsername').value);
 }

--- a/public/javascripts/newGroup.js
+++ b/public/javascripts/newGroup.js
@@ -4,7 +4,7 @@ window.onload = function() {
 
 function newGroup() {
   if (!user.isLoggedIn()) {
-    window.alert('No user data found, please log in before making a new Group.');
+    window.alert('Please log in before making a new group');
     return;
   }
   var groupname = document.getElementById('group-name').value;
@@ -25,6 +25,15 @@ function newGroup() {
 }
 
 function newGroupError(err) {
-  console.log(err);
-  window.alert(err);
+  // Try to extract the error for the groupname field.
+  var nameErr;
+  try {
+    nameErr = err.responseJSON.errors.groupname.msg;
+  } catch {}
+
+  var msg = "Failed to add group"
+  if (nameErr !== null) {
+    msg = msg + ": " + nameErr;
+  }
+  window.alert(msg);
 }

--- a/public/javascripts/userHome.js
+++ b/public/javascripts/userHome.js
@@ -1,14 +1,14 @@
 window.onload = function() {
-  document.getElementById('username').innerText = user.get("username");
-  document.getElementById('first-name').innerText = user.get("firstname");
-  document.getElementById('last-name').innerText = user.get("lastname");
-  document.getElementById('email').innerText = user.get("email");
+  document.getElementById('username').innerText = user.getAttr("username");
+  document.getElementById('first-name').innerText = user.getAttr("firstname");
+  document.getElementById('last-name').innerText = user.getAttr("lastname");
+  document.getElementById('email').innerText = user.getAttr("email");
   document.getElementById('groups').innerText = getGroupsListText();
 };
 
 function getGroupsListText() {
   var groups = [];
-  var userGroups = user.get("groups");
+  var userGroups = user.getAttr("groups");
   for (var i in userGroups)
     groups.push(userGroups[i].groupname);
   return groups.join(', ');


### PR DESCRIPTION
This PR contains a few fixes.

### Fix error output when group addition fails 

When the API request to add a group failed a dialog box saying `Object [object]` was shown. The actual error is now extracted from the API request and included in a more sensible error message.

### Fix loading of user data after groups are added

The API being used to refresh the logged in user's data after a group was added returns data for all users instead of the current user as the UI code was expecting. This caused bad data to be stored in
localstorage and broke the user's session (requiring the user log in again to fix).

A simpler API is now used which just returns the details for a single user.

### Use the new, simpler user API on devices & groups screens

Instead of using the API which retrieves details for all users use `/api/v1/users/:username` instead. The helper for calling this has been moved to the shared user module instead being duplicated in the
devices and groups modules.

### eslint

Added configuration for eslint and fixed numerous minor problems.