### PR TITLE
Various js fixes

### DIFF
--- a/public/javascripts/includes/user.js
+++ b/public/javascripts/includes/user.js
@@ -22,10 +22,7 @@ user.login = function(passwordElement, usernameElement) {
     error: function(res) {
       document.getElementById('inputUsername').value = '';
       document.getElementById('inputPassword').value = '';
-      var messages = JSON.parse(res.responseText).messages.join('.');
-      console.log(messages);
-      window.alert(messages);
-      document.getElementById('messages').innerHTML = messages;
+      window.alert('login failed');
     }
   });
 };

--- a/public/javascripts/newGroup.js
+++ b/public/javascripts/newGroup.js
@@ -29,9 +29,11 @@ function newGroupError(err) {
   var nameErr;
   try {
     nameErr = err.responseJSON.errors.groupname.msg;
-  } catch {}
+  } catch(error) {
+    // ignore
+  }
 
-  var msg = "Failed to add group"
+  var msg = "Failed to add group";
   if (nameErr !== null) {
     msg = msg + ": " + nameErr;
   }

--- a/views/includes/base.pug
+++ b/views/includes/base.pug
@@ -2,5 +2,5 @@ script(type='text/javascript').
   var api = "!{api}";
 script(type='text/javascript', src='/javascripts/includes/user.js')
 script(src='https://code.jquery.com/jquery-2.2.4.js')
-script(src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js")
+script(src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js")
 link(href='/stylesheets/bootstrap.css', rel='stylesheet', media='screen')


### PR DESCRIPTION
* Fix invalid catch syntax in newGroup.js
* Remove invalid message extraction on login screen
* Pull bootstrap's JS via HTTPS. This was getting blocked in real deployments because pulling HTTP from a HTTPS served page is a no-no with modern browsers.