### PR TITLE
Set node version 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "8.9.4"
 
 script:
   - npm run lint


### PR DESCRIPTION
Just copying the change I made to cacophony-api to this project to which makes the travis build always use a specified node version not the latest node version. 