### PR TITLE
Add query by animal tags (plus refactor query code)

### DIFF
--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -87,15 +87,16 @@ function addDeviceToList(device) {
   }
   // Create element and add to deviceList
   let element = document.createElement("button");
-  let span = ' <span class="badge badge-secondary"><i class="fas fa-times"></i></span>';
+  let span = ' <span class="badge badge-secondary" style="cursor: pointer;"><i class="fas fa-times"></i></span>';
   element.innerHTML = device.name + span;
   element.id = device.id;
   element.classList.add("btn");
+  element.style.cursor = "auto";
   deviceList.appendChild(element);
   // Add event listener for removal
   element = document.getElementById(device.id);
-  element.addEventListener('click', (event) => {
-    removeDeviceFromList(event.target.id);
+  element.children[0].addEventListener('click', () => {
+    removeDeviceFromList(device.id);
   });
   // Change placeholder text
   let deviceInput = document.getElementById('deviceInput');

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -29,9 +29,6 @@ window.onload = function() {
   let deviceInputElement = document.getElementById('deviceInput');
   deviceInputElement.addEventListener('input', filterDropdown);
 
-  // Add event listeners for animal selection
-  // let animalInputElement = document.getElementById('animals');
-  // animalInputElement.addEventListener('input', addAnimal);
 };
 
 // DEVICE LIST FUNCTIONS
@@ -304,17 +301,27 @@ function sendQuery() {
   var limit = Number(document.getElementById('limit').value);
   var offset = Number(document.getElementById('offset').value);
   var tagMode = $('select#tagMode').val();
+  // Build query data
+  let data = {
+    where: query,
+    limit: limit,
+    offset: offset,
+    tagMode: tagMode
+  };
+
+  // Get animals
+  let animals = [];
+  let animalSelected = document.getElementById('animals').value;
+  if (animalSelected !== "all") {
+    animals.push(animalSelected);
+    data.tags = JSON.stringify(animals);
+  }
 
   var url = recordingsApiUrl;
   $.ajax({
     url: url,
     type: 'GET',
-    data: {
-      where: query,
-      limit: limit,
-      offset: offset,
-      tagMode: tagMode,
-    },
+    data: data,
     headers: { Authorization: user.getJWT() },
     success: function(res) {
       console.log('Successful request:', res);

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -186,7 +186,7 @@ function filterDropdown() {
   }
 }
 
-//===============ADD CONDITIONS==================
+// DURATION SLIDER FUNCTIONS
 
 var durationMax = 100;
 
@@ -242,31 +242,9 @@ function changeDurationSliderMax() {
   durationGhostElement.style.setProperty("--high", 100 * durationElement.valueHigh / durationMax - 1 + "%");
 }
 
-// Increase query offset, view next set of results.
-function inc() {
-  var offset = document.getElementById('offset');
-  var offsetN = Number(offset.value);
-  var limitN = Number(document.getElementById('limit').value);
-  if (offsetN + limitN < count) {
-    offset.value = offsetN + limitN;
-  }
-  sendQuery();
-}
+// QUERY FUNCTIONS
 
-// Decrease query offset, vew previous set of results.
-function dec() {
-  var offset = document.getElementById('offset');
-  var offsetN = Number(offset.value);
-  var limitN = Number(document.getElementById('limit').value);
-  var newOffsetVal = offsetN - limitN;
-  if (newOffsetVal <= 0) {
-    newOffsetVal = 0;
-  }
-  offset.value = newOffsetVal;
-  sendQuery();
-}
-
-// Creates a query string (replaces active query HTML field)
+// Creates a query string
 function buildQuery() {
   let query = {type: 'thermalRaw'};
 
@@ -367,6 +345,32 @@ function clearTable() {
     table.deleteRow(rowCount);
   }
 }
+
+// Increase query offset, view next set of results.
+function inc() {
+  var offset = document.getElementById('offset');
+  var offsetN = Number(offset.value);
+  var limitN = Number(document.getElementById('limit').value);
+  if (offsetN + limitN < count) {
+    offset.value = offsetN + limitN;
+  }
+  sendQuery();
+}
+
+// Decrease query offset, vew previous set of results.
+function dec() {
+  var offset = document.getElementById('offset');
+  var offsetN = Number(offset.value);
+  var limitN = Number(document.getElementById('limit').value);
+  var newOffsetVal = offsetN - limitN;
+  if (newOffsetVal <= 0) {
+    newOffsetVal = 0;
+  }
+  offset.value = newOffsetVal;
+  sendQuery();
+}
+
+// TABLE FUNCTIONS
 
 // Parses throug a Datapoint and adds it to the result table.
 function appendDatapointToTable(datapoint) {

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -29,19 +29,13 @@ window.onload = function() {
   durationElement.addEventListener('input', updateDurationLabels);
   durationGhostElement.addEventListener('input', updateDurationLabels);
 
-  // Add event listeners for date selection
-  let fromDateElement = document.getElementById('fromDate');
-  let toDateElement = document.getElementById('toDate');
-  fromDateElement.addEventListener('input', addFromDate);
-  toDateElement.addEventListener('input', addToDate);
-
   // Add event listeners for device selection
   let deviceInputElement = document.getElementById('deviceInput');
   deviceInputElement.addEventListener('input', filterDropdown);
 
   // Add event listeners for animal selection
   let animalInputElement = document.getElementById('animals');
-  animalInputElement.addEventListener('input', addAnimal);
+  // animalInputElement.addEventListener('input', addAnimal);
 };
 
 // DEVICE LIST FUNCTIONS
@@ -83,6 +77,8 @@ function getGroups() {
   });
 }
 
+// Returns an array of devices, where each devices is an object with name, id,
+// and array of users
 function getDevices() {
   const data = JSON.stringify({});
   const headers = {};
@@ -103,12 +99,11 @@ function getDevices() {
   });
 }
 
-// Populate list with devices
+// Populate the device dropdown with devices and groups of devices
 async function deviceDropdown() {
   // Extract data from API
   let devices = await getDevices();
   let groups = await getGroups();
-
   // Add devices to dropdown
   let dropdownMenu = document.getElementsByClassName("dropdown-menu")[0];
   for (let device of devices) {
@@ -136,8 +131,6 @@ async function deviceDropdown() {
       addDeviceToList(device);
     });
   }
-
-
 }
 
 // Add device to list of selected devices
@@ -209,46 +202,6 @@ function addCondition(sequelizeCondition) {
 // Removes a Sequelize condition with the given ID.
 function deleteCondition(id) {
   delete conditions[id];
-}
-
-function addToDate() {
-  // Remove any existing toDate conditions
-  for (let i in conditions) {
-    if (conditions[i].recordingDateTime !== undefined) {
-      if (conditions[i].recordingDateTime.$lt !== undefined) {
-        deleteCondition(i);
-      }
-    }
-  }
-  // Add new condition
-  var date = document.getElementById('toDate').value;
-  if (date != "") {
-    addCondition({ recordingDateTime: { "$lt": date} });
-  }
-}
-
-function addFromDate() {
-  // Remove any existing fromDate conditions
-  for (let i in conditions) {
-    if (conditions[i].recordingDateTime !== undefined) {
-      if (conditions[i].recordingDateTime.$gt !== undefined) {
-        deleteCondition(i);
-      }
-    }
-  }
-  // Add new condition
-  var date = document.getElementById('fromDate').value;
-  if (date != "") {
-    addCondition({ recordingDateTime: { "$gt": date } });
-  }
-}
-
-function addAnimal() {
-  // Remove any existing animal conditions
-
-  // Add new condition
-  let animal = document.getElementById('animals').value;
-  addCondition({ animal: animal });
 }
 
 var durationMax = 100;
@@ -396,6 +349,20 @@ function buildQuery() {
       }
     }
   }
+
+  // Add date conditions to query
+  let fromDate = document.getElementById('fromDate').value;
+  let toDate = document.getElementById('toDate').value;
+  if (fromDate !== "" || toDate !== "") {
+    query.recordingDateTime = {};
+  }
+  if (fromDate !== "") {
+    query.recordingDateTime["$gt"] = fromDate;
+  }
+  if (toDate != "") {
+    query.recordingDateTime["$lt"] = toDate;
+  }
+
   console.log("Query: \n", query);
   return JSON.stringify(query);
 }

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -52,6 +52,10 @@ window.onload = function() {
   // Add event listeners for device selection
   let deviceInputElement = document.getElementById('deviceInput');
   deviceInputElement.addEventListener('input', filterDropdown);
+
+  // Add event listeners for animal selection
+  let animalInputElement = document.getElementById('animals');
+  animalInputElement.addEventListener('input', addAnimal);
 };
 
 // DEVICE LIST FUNCTIONS
@@ -224,6 +228,14 @@ function addFromDate() {
   if (date != "") {
     addCondition({ recordingDateTime: { "$gt": date } });
   }
+}
+
+function addAnimal() {
+  // Remove any existing animal conditions
+
+  // Add new condition
+  let animal = document.getElementById('animals').value;
+  addCondition({ animal: animal });
 }
 
 var durationMax = 100;

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -27,13 +27,18 @@ window.onload = function() {
 
   // Add event listeners for device selection
   let deviceInputElement = document.getElementById('deviceInput');
-  deviceInputElement.addEventListener('input', filterDropdown);
+  deviceInputElement.addEventListener('input', filterDeviceDropdown);
 
   // Add event listeners for animal selection
-  let animalInputElement = document.getElementById('animals');
-  animalInputElement.addEventListener('input', (event) => {
-    addAnimalToList(event.target.value);
-  });
+  let animalDropdownElement = document.getElementById('animalDropdown');
+  let animalItems = animalDropdownElement.children;
+  for (let item of animalItems) {
+    item.addEventListener('click', (event) => {
+      addAnimalToList(event.target.innerText);
+    });
+  }
+  let animalInputElement = document.getElementById('animalInput');
+  animalInputElement.addEventListener('input', filterAnimalDropdown);
 };
 
 // DEVICE LIST FUNCTIONS
@@ -174,7 +179,7 @@ function removeDeviceFromList(deviceId) {
 }
 
 // Filter dropdown to hide devices as you type
-function filterDropdown() {
+function filterDeviceDropdown() {
   let input = document.getElementById("deviceInput");
   let filter = input.value.toUpperCase();
   let div = document.getElementsByClassName("dropdown-menu")[0];
@@ -246,20 +251,19 @@ function changeDurationSliderMax() {
 
 // ANIMAL SELECTOR FUNCTIONS
 
-// Add device to list of selected devices
+// Add animal to list of selected animals
 function addAnimalToList(animal) {
   let animalList = document.getElementById("animalList");
   // Check whether it is already selected
   for (let listItem of animalList.children) {
-    console.log(listItem);
     if (listItem.id === animal) {
       // Change placeholder text
-      let animalInput = document.getElementById('animals');
+      let animalInput = document.getElementById('animalInput');
       animalInput.value = 'add another animal';
       return;
     }
   }
-  // Create element and add to deviceList
+  // Create element and add to animalList
   let element = document.createElement("button");
   let span = ' <span class="badge badge-secondary" style="cursor: pointer;"><i class="fas fa-times"></i></span>';
   element.innerHTML = animal + span;
@@ -273,23 +277,37 @@ function addAnimalToList(animal) {
     removeAnimalFromList(animal);
   });
   // Change placeholder text
-  let animalInput = document.getElementById('animals');
-  animalInput.value = 'add another animal';
+  let animalInput = document.getElementById('animalInput');
+  animalInput.placeholder = 'add another animal';
 }
 
-// Remove device from list of selected devices
+// Remove animal from list of selected animals
 function removeAnimalFromList(animal) {
-  console.log('here');
   let animalList = document.getElementById("animalList");
   for (let listItem of animalList.children) {
     if (listItem.id === animal) {
       animalList.removeChild(listItem);
     }
   }
-  // Change placeholder text if no devices left
+  // Change placeholder text if no animals left
   if (animalList.children.length === 0) {
-    let animalInput = document.getElementById('animals');
-    animalInput.value = 'all';
+    let animalInput = document.getElementById('animalInput');
+    animalInput.placeholder = 'all animals';
+  }
+}
+
+// Filter dropdown to hide animals as you type
+function filterAnimalDropdown() {
+  let input = document.getElementById("animalInput");
+  let filter = input.value.toUpperCase();
+  let div = document.getElementsByClassName("dropdown-menu")[0];
+  let items = div.getElementsByTagName("div");
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].innerHTML.toUpperCase().indexOf(filter) > -1) {
+      items[i].style.display = "";
+    } else {
+      items[i].style.display = "none";
+    }
   }
 }
 
@@ -365,7 +383,7 @@ function sendQuery() {
 
   // Get animals
   let animals = [];
-  let animalSelected = document.getElementById('animals').value;
+  let animalSelected = document.getElementById('animalInput').value;
   if (animalSelected !== "all") {
     let animalList = document.getElementById('animalList');
     for (let animal of animalList.children) {

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -14,8 +14,6 @@ var devicesApiUrl = api + '/api/v1/devices';
 var viewUrl = '/view_recording/';
 const groupsApiUrl = api + '/api/v1/groups';
 
-const conditions = {};
-var nextId = 1;
 var count = 54;
 
 window.onload = function() {
@@ -24,8 +22,6 @@ window.onload = function() {
   // Add event listeners for duration slider
   let durationElement = document.getElementById('duration');
   let durationGhostElement = findGhost('duration');
-  durationElement.addEventListener('change', addDurationFromSlider);
-  durationGhostElement.addEventListener('change', addDurationFromSlider);
   durationElement.addEventListener('input', updateDurationLabels);
   durationGhostElement.addEventListener('input', updateDurationLabels);
 
@@ -34,7 +30,7 @@ window.onload = function() {
   deviceInputElement.addEventListener('input', filterDropdown);
 
   // Add event listeners for animal selection
-  let animalInputElement = document.getElementById('animals');
+  // let animalInputElement = document.getElementById('animals');
   // animalInputElement.addEventListener('input', addAnimal);
 };
 
@@ -190,40 +186,9 @@ function filterDropdown() {
   }
 }
 
-
-
 //===============ADD CONDITIONS==================
-// Adds a Sequelize condition.
-function addCondition(sequelizeCondition) {
-  var id = nextId++;
-  conditions[id] = sequelizeCondition;
-}
-
-// Removes a Sequelize condition with the given ID.
-function deleteCondition(id) {
-  delete conditions[id];
-}
 
 var durationMax = 100;
-
-function addDurationFromSlider() {
-  // Remove any existing duration conditions
-  for (let i in conditions) {
-    if (conditions[i].duration !== undefined) {
-      deleteCondition(i);
-    }
-  }
-
-  let durationElement = document.getElementById('duration');
-  let durationHigh = durationElement.valueHigh;
-  let durationLow = durationElement.valueLow;
-
-  // Add new duration conditions
-  addCondition({ duration: { "$lt": durationHigh } });
-  addCondition({ duration: { "$gt": durationLow } });
-
-  updateDurationLabels();
-}
 
 function updateDurationLabels() {
   let durationGhostElement = findGhost('duration');
@@ -275,7 +240,6 @@ function changeDurationSliderMax() {
   durationGhostElement.max = durationMax;
   durationGhostElement.style.setProperty("--low", 100 * durationElement.valueLow / durationMax + 1 + "%");
   durationGhostElement.style.setProperty("--high", 100 * durationElement.valueHigh / durationMax - 1 + "%");
-  addDurationFromSlider();
 }
 
 // Increase query offset, view next set of results.
@@ -323,31 +287,17 @@ function buildQuery() {
     }
   }
 
-  // Add conditions to query
-  for (var i in conditions) {
-    var condition = conditions[i];
-    // Two examples that condition could be:
-    // {duration: {$lt: 10}} Duration should be less than 4.
-    // {duration: 2}        Duration should be equal to 2.
-    for (var key in condition) {
-      // Adding empty object if one is not already defined for that key.
-      if (query[key] === undefined) {
-        query[key] = {};
-      }
-
-      // If condition is an object append each condition. {duration: {$lt: 4}}
-      // Just one condition in this case.
-      // query.duration.$lt = 4;
-      if (typeof condition[key] === 'object') {
-        for (var j in condition[key]) {
-          query[key][j] = condition[key][j];
-        }
-      } else {
-        // If not a object just set key to that value. {duration: 2}
-        // query.duration = 2;
-        query[key] = condition[key];
-      }
-    }
+  // Add duration condition to query
+  let durationText = document.getElementById('durationText').innerText;
+  // Check whether the duration slider has moved or whether is still at default
+  // values
+  if (durationText !== "0 to max sec") {
+    let durationLow = document.getElementById('duration').valueLow;
+    let durationHigh = document.getElementById('duration').valueHigh;
+    query.duration = {
+      "$lt": durationHigh,
+      "$gt": durationLow
+    };
   }
 
   // Add date conditions to query

--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -29,6 +29,11 @@ window.onload = function() {
   let deviceInputElement = document.getElementById('deviceInput');
   deviceInputElement.addEventListener('input', filterDropdown);
 
+  // Add event listeners for animal selection
+  let animalInputElement = document.getElementById('animals');
+  animalInputElement.addEventListener('input', (event) => {
+    addAnimalToList(event.target.value);
+  });
 };
 
 // DEVICE LIST FUNCTIONS
@@ -239,6 +244,55 @@ function changeDurationSliderMax() {
   durationGhostElement.style.setProperty("--high", 100 * durationElement.valueHigh / durationMax - 1 + "%");
 }
 
+// ANIMAL SELECTOR FUNCTIONS
+
+// Add device to list of selected devices
+function addAnimalToList(animal) {
+  let animalList = document.getElementById("animalList");
+  // Check whether it is already selected
+  for (let listItem of animalList.children) {
+    console.log(listItem);
+    if (listItem.id === animal) {
+      // Change placeholder text
+      let animalInput = document.getElementById('animals');
+      animalInput.value = 'add another animal';
+      return;
+    }
+  }
+  // Create element and add to deviceList
+  let element = document.createElement("button");
+  let span = ' <span class="badge badge-secondary" style="cursor: pointer;"><i class="fas fa-times"></i></span>';
+  element.innerHTML = animal + span;
+  element.id = animal;
+  element.classList.add("btn");
+  element.style.cursor = "auto";
+  animalList.appendChild(element);
+  // Add event listener for removal
+  element = document.getElementById(animal);
+  element.children[0].addEventListener('click', () => {
+    removeAnimalFromList(animal);
+  });
+  // Change placeholder text
+  let animalInput = document.getElementById('animals');
+  animalInput.value = 'add another animal';
+}
+
+// Remove device from list of selected devices
+function removeAnimalFromList(animal) {
+  console.log('here');
+  let animalList = document.getElementById("animalList");
+  for (let listItem of animalList.children) {
+    if (listItem.id === animal) {
+      animalList.removeChild(listItem);
+    }
+  }
+  // Change placeholder text if no devices left
+  if (animalList.children.length === 0) {
+    let animalInput = document.getElementById('animals');
+    animalInput.value = 'all';
+  }
+}
+
 // QUERY FUNCTIONS
 
 // Creates a query string
@@ -288,7 +342,7 @@ function buildQuery() {
     query.recordingDateTime["$lt"] = toDate;
   }
 
-  console.log("Query: \n", query);
+  console.log("Query: \n", JSON.stringify(query));
   return JSON.stringify(query);
 }
 
@@ -313,8 +367,12 @@ function sendQuery() {
   let animals = [];
   let animalSelected = document.getElementById('animals').value;
   if (animalSelected !== "all") {
-    animals.push(animalSelected);
+    let animalList = document.getElementById('animalList');
+    for (let animal of animalList.children) {
+      animals.push(animal.id);
+    }
     data.tags = JSON.stringify(animals);
+    console.log("Animals:", data.tags);
   }
 
   var url = recordingsApiUrl;

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -39,26 +39,29 @@ html
         //- Animals
         .form-group.col-sm-4
           label Animals
-          select.form-control#animals
-            option all
-            option bird
-            option bird/kiwi
-            option rat
-            option possum
-            option hedgehog
-            option stoat
-            option ferret
-            option weasel
-            option mouse
-            option cat
-            option dog
-            option rabbit
-            option hare
-            option human
-            option spider
-            option insect
-            option other
-            option unidentified
+          .form-row#animalList(style="margin-right: 0; margin-left: 0;")
+          .form-row(style="margin-right: 0; margin-left: 0;")
+            select.form-control#animals
+              option all
+              option bird
+              option bird/kiwi
+              option rat
+              option possum
+              option hedgehog
+              option stoat
+              option ferret
+              option weasel
+              option mouse
+              option cat
+              option dog
+              option rabbit
+              option hare
+              option human
+              option spider
+              option insect
+              option other
+              option unidentified
+              option#addAnotherAnimal(style="display: none;") add another animal
         
         //- Duration
         .form-group.col-sm-4

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -19,9 +19,11 @@ html
         
         //- Devices
         .form-group.col-sm-4
-          label Devices
-          select.form-control#deviceSelect
-            option all
+          label Device
+          .form-row#deviceList(style="margin-right: 0; margin-left: 0;")
+          .dropdown
+            input#deviceInput.form-control.dropdown-toggle(data-toggle="dropdown" placeholder="all devices")
+            .dropdown-menu
         
         //- Tags
         .form-group.col-sm-4

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -25,7 +25,7 @@ html
             input#deviceInput.form-control.dropdown-toggle(data-toggle="dropdown" placeholder="all devices")
             .dropdown-menu
         
-        //- Tags
+        //- Tag Types
         .form-group.col-sm-4
           label Tag Types
           select.form-control#tagMode
@@ -35,6 +35,30 @@ html
             option(value="automatic-only") automatic only
             option(value="human-only") manual only
             option(value="automatic+human") both automatic & manual
+        
+        //- Animals
+        .form-group.col-sm-4
+          label Animals
+          select.form-control#animals
+            option all
+            option bird
+            option bird/kiwi
+            option rat
+            option possum
+            option hedgehog
+            option stoat
+            option ferret
+            option weasel
+            option mouse
+            option cat
+            option dog
+            option rabbit
+            option hare
+            option human
+            option spider
+            option insect
+            option other
+            option unidentified
         
         //- Duration
         .form-group.col-sm-4

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -64,7 +64,7 @@ html
         .form-group.col-sm-4
           label Duration (sec)
           .row
-            .col-6
+            .col-6#durationText
               span#durationLow 0
               span &nbsp;to&nbsp;
               span#durationHigh max
@@ -75,7 +75,7 @@ html
               a(onclick='changeDurationSliderMax()')
                 i#durationMaxChange.fas.fa-angle-double-right(style="display: none; text-decoration: none;")
           .col(style="padding-right: 0; padding-left: 0;")
-            input.form-control#duration(type='range' multiple value='0,100' onchange='addDurationFromSlider()' max='100')
+            input.form-control#duration(type='range' multiple value='0,100' max='100')
           
         //- Date range
         .form-group.col

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -27,7 +27,7 @@ html
         
         //- Tags
         .form-group.col-sm-4
-          label Tags
+          label Tag Types
           select.form-control#tagMode
             option(value="any" selected) any
             option(value="untagged") untagged only

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -41,27 +41,29 @@ html
           label Animals
           .form-row#animalList(style="margin-right: 0; margin-left: 0;")
           .form-row(style="margin-right: 0; margin-left: 0;")
-            select.form-control#animals
-              option all
-              option bird
-              option bird/kiwi
-              option rat
-              option possum
-              option hedgehog
-              option stoat
-              option ferret
-              option weasel
-              option mouse
-              option cat
-              option dog
-              option rabbit
-              option hare
-              option human
-              option spider
-              option insect
-              option other
-              option unidentified
-              option#addAnotherAnimal(style="display: none;") add another animal
+            input#animalInput.form-control.dropdown-toggle(data-toggle="dropdown" placeholder="all animals")
+            .dropdown-menu#animalDropdown
+              .dropdown-item bird
+              .dropdown-item bird/kiwi
+              .dropdown-item cat
+              .dropdown-item dog
+              .dropdown-item ferret
+              .dropdown-item hare
+              .dropdown-item hedgehog
+              .dropdown-item human
+              .dropdown-item insect
+              .dropdown-item mouse
+              .dropdown-item possum
+              .dropdown-item rabbit
+              .dropdown-item rat
+              .dropdown-item spider
+              .dropdown-item stoat
+              .dropdown-item weasel
+              .dropdown-item other
+              .dropdown-divider
+              .dropdown-item false-positive
+              .dropdown-item interesting
+              .dropdown-item unidentified
         
         //- Duration
         .form-group.col-sm-4


### PR DESCRIPTION
I have added a box to query by animal to the getRecordings page. A dropdown menu lists all of the animals. When you click on an animal, it is added to the selection list in a similar fashion to the device selection. Clicking X removes it etc.

I have also re-written significant portions of the getRecordings.js to completely remove the 'conditions' variable, which was a hang-on from when the conditions were displayed on the page. No functional changes from the users perspective, but hopefully cleaner for devs. A thorough check of functionality would be appreciated as there may be a few bugs beyond just the addition of the animal tags...

NB This probably should require #88 to be merged first as that updates the device selection, or may render it unneeded... not sure :-S
References #81 

![animalselection](https://user-images.githubusercontent.com/24260476/42253745-5471f30e-7f97-11e8-87f7-2a94e40f7074.png)