### PR TITLE
Add processed state to table in query view

### DIFF
--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -597,6 +597,13 @@ function parseOther() {
   return td;
 }
 
+function parseProcessingState(result) {
+  let td = document.createElement("td");
+  let string = result.processingState.toLowerCase();
+  string = string.charAt(0).toUpperCase() + string.slice(1);
+  td.innerHTML = string;
+  return td;
+}
 
 // Generates a Download button to download the recording
 function parseDownload(id, type) {
@@ -705,6 +712,11 @@ function getTableData() {
     tableName: "File",
     datapointField: "id",
     parseFunction: parseDownloadRaw
+  },
+  {
+    tableName: "Processing State",
+    datapointField: "datapoint",
+    parseFunction: parseProcessingState
   },
   ];
 }

--- a/views/getRecordings.pug
+++ b/views/getRecordings.pug
@@ -124,5 +124,6 @@ html
           th Other
           th File
           th Raw data
+          th Processing State
 
     include includes/footer.pug


### PR DESCRIPTION
I've decided to work through some of the older issues in the backlog... starting with #13 

This adds the processed state to the table in the query view. Things to consider:

- I don't know what else shows up other than finished
- Do we want to re-order the columns and/or remove any redundant columns?