### PR TITLE
Add confirm button for AI tags

### DIFF
--- a/public/javascripts/includes/tags.js
+++ b/public/javascripts/includes/tags.js
@@ -82,8 +82,22 @@ tags.addTagToTable = function(tag) {
   del.appendChild(deleteButton);
   row.appendChild(del);
 
+  // Add a confirm button if tag created by Cacophony AI
+  var confirm = document.createElement('td');
+  console.log(tag);
+  if (tag.automatic  && tag.animal !== "unidentified") {
+    var confirmButton = document.createElement('button');
+    confirmButton.innerHTML = "<i class='fas fa-check-circle fa-3x text-secondary'></i>";
+    confirmButton.onclick = tags.confirm;
+    confirmButton.tagId = tag.id;
+    confirmButton.tagRow = row;
+    confirm.appendChild(confirmButton);
+  }
+  row.appendChild(confirm);
+
+
   if (tag.number != null && tag.number > 1.5) {
-    additionalInfo.innerHTML += "<p> Number of animals is '" + tag.number + "'</p>";  
+    additionalInfo.innerHTML += "<p> Number of animals is '" + tag.number + "'</p>";
   }
 
   if (tag.event != null && tag.event != "just wandering about") {
@@ -192,6 +206,21 @@ tags.quickNew = function(animal) {
   tags.send(tag);
 };
 
+tags.confirm = function(tag) {
+  let tr = tag.target.parentNode.parentNode.parentNode;
+  let animal = tr.children[0].innerText;
+  if (animal === "-") {
+    // false positive
+    let tag = {};
+    tag.event = "false positive";
+    tag.confidence = 0.6;
+    console.log(tags.parseSelect('tagEventInput'));
+    tags.send(tag);
+  } else {
+    tags.quickNew(animal);
+  }
+  tag.target.classList.replace('text-secondary', 'text-success');
+};
 
 tags.send = function(tag) {
   var data = {recordingId: id};
@@ -265,7 +294,7 @@ tags.parseTime = function(id) {
 };
 
 /**
- * Takes time in total seconds and parses it back into minutes and seconds format. 
+ * Takes time in total seconds and parses it back into minutes and seconds format.
  */
 tags.displayTime = function(timeInSeconds) {
   var timeString = "";

--- a/public/javascripts/includes/tags.js
+++ b/public/javascripts/includes/tags.js
@@ -215,7 +215,6 @@ tags.confirm = function(tag) {
     let tag = {};
     tag.event = "false positive";
     tag.confidence = 0.6;
-    console.log(tags.parseSelect('tagEventInput'));
     tags.send(tag);
   } else {
     tags.quickNew(animal);

--- a/views/includes/tagSummary.pug
+++ b/views/includes/tagSummary.pug
@@ -9,7 +9,8 @@ table.tag-summary.table.table-hover
       th(title='Who analysed the footage?') By who
       th(title='When did they analyse the footage?') When
       th Additional info
-      th
+      th Delete
+      th Confirm
   tbody#tags-table
     tr.no-tags#no-tags
       td(colspan=7) No tags have been recorded for this video


### PR DESCRIPTION
On the view recording screen, I've added a button next to an AI identification. This only shows for AI tags and only if it is a positive identification (ie not for false positives or unidentified tags). When the button is pushed, a manual tag is added with the same animal ID as the AI.

I don't know if this is what you intended or not but this seemed straightforward... can tweak a few things eg keep the confirm button green if there is already a positive confirmation

References #54