### PR TITLE
Fix empty device group issue

### DIFF
--- a/public/javascripts/getRecordings.js
+++ b/public/javascripts/getRecordings.js
@@ -120,7 +120,12 @@ async function deviceDropdown() {
   for (let group of groups) {
     let item = document.createElement("div");
     item.innerText = group.name + " (group)";
-    item.id = group.devices;
+    if (group.devices.length > 0) {
+      item.id = group.devices;
+    } else {
+      item.id = "none" + group.name;
+    }
+
     item.classList.add("dropdown-item");
     dropdownMenu.appendChild(item);
   }
@@ -335,10 +340,13 @@ function buildQuery() {
     query.DeviceId = [];
     for (let device of deviceList.children) {
       if (device.innerText.slice(-8) === "(group) ") {
-        // Add IDs for groups separately
-        let devices = device.id.split(',');
-        for (let id of devices) {
-          query.DeviceId.push(id);
+        // Check whether the device group has no devices
+        if (device.id.slice(0,4) !== "none") {
+          // Add IDs for groups separately
+          let devices = device.id.split(',');
+          for (let id of devices) {
+            query.DeviceId.push(id);
+          }
         }
       } else {
         query.DeviceId.push(device.id);


### PR DESCRIPTION
Fix #103 

The original issue happened because there was no element ID set if there were no device IDs. I have added a check to see whether the number of devices is = 0. If so, make the element id 'none' + group.name to mitigate the X not working. However, this also required this to be removed when running a query so that now checks whether the id begins with 'none' in which case do not add any device IDs for that group.