### PR TITLE
Remove double event handling for audiobait device selection

### DIFF
--- a/public/javascripts/setupAudio.js
+++ b/public/javascripts/setupAudio.js
@@ -41,7 +41,7 @@ window.onload = function() {
       schedule.devices = result.devices;
       populateDevicesSelect(document.getElementById("deviceSelect"));
       $("#loading-message").addClass("hide");
-      $("#choose-device").click(getSchedule).removeClass("hide");
+      $("#choose-device").change(getSchedule).removeClass("hide");
     },
     error: function(err) {
       $("#loading-message").text("Failed to find any devices that you can set.");

--- a/views/setupAudio.pug
+++ b/views/setupAudio.pug
@@ -23,7 +23,7 @@ html
 
         #choose-device.hide.row.col-xs-12
           label.col-xs-6 Choose Device
-          select#deviceSelect.col-xs-6(onchange="getSchedule()")
+          select#deviceSelect.col-xs-6
             option(value="select") &lt;select your device&gt;
           span.col-xs-12 (To edit an existing schedule choose a device on that schedule)
 


### PR DESCRIPTION
A change was missed in 956145fd meaning that devices and schedules
would show up twice in the main audiobait UI.